### PR TITLE
Fixed to make synthesizer v1.0 work with the new captcha'd speech api.

### DIFF
--- a/src/com/darkprograms/speech/synthesiser/Synthesiser.java
+++ b/src/com/darkprograms/speech/synthesiser/Synthesiser.java
@@ -116,14 +116,12 @@ public class Synthesiser {
 			return out;
 		}
 
-
 		String encoded = URLEncoder.encode(synthText, "UTF-8"); //Encode
 
-		URL url = new URL(GOOGLE_SYNTHESISER_URL + languageCode + "&q=" + encoded); //create url
-
+		URL url = new URL(GOOGLE_SYNTHESISER_URL + languageCode + "&q=" + encoded + "&ie=UTF-8&total=1&idx=0&client=t");
 		// Open New URL connection channel.
 		URLConnection urlConn = url.openConnection(); //Open connection
-
+		
 		urlConn.addRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:2.0) Gecko/20100101 Firefox/4.0"); //Adding header for user agent is required
 
 		return urlConn.getInputStream();


### PR DESCRIPTION
Changed the URL in Synthesizer (v 1.0) because of how the previous URL got a captcha on it. Should work the same as before (at least, it has in my testing).