### PR TITLE
Multiple code improvements - squid:S1149, squid:S1118, squid:S1213, squid:S2259, squid:S1905, squid:S00122

### DIFF
--- a/src/main/java/com/darkprograms/speech/microphone/Microphone.java
+++ b/src/main/java/com/darkprograms/speech/microphone/Microphone.java
@@ -11,17 +11,18 @@ import java.io.File;
  * @author Luke Kuza, Aaron Gokaslan
  ***************************************************************************/
 public class Microphone implements Closeable{
-	
+
     /**
      * TargetDataLine variable to receive data from microphone
      */
     private TargetDataLine targetDataLine;
 
+
     /**
      * Enum for current Microphone state
      */
     public enum CaptureState {
-        PROCESSING_AUDIO, STARTING_CAPTURE, CLOSED
+        PROCESSING_AUDIO, STARTING_CAPTURE, CLOSED;
     }
 
     /**
@@ -38,6 +39,18 @@ public class Microphone implements Closeable{
      * Variable that holds the saved audio file
      */
     private File audioFile;
+
+    /**
+     * Constructor
+     *
+     * @param fileType File type to save the audio in<br>
+     *                 Example, to save as WAVE use AudioFileFormat.Type.WAVE
+     */
+    public Microphone(AudioFileFormat.Type fileType) {
+        setState(CaptureState.CLOSED);
+        setFileType(fileType);
+        initTargetDataLine();
+    }
 
     /**
      * Gets the current state of Microphone
@@ -79,21 +92,9 @@ public class Microphone implements Closeable{
         return targetDataLine;
     }
 
+    
     public void setTargetDataLine(TargetDataLine targetDataLine) {
         this.targetDataLine = targetDataLine;
-    }
-    
-    
-    /**
-     * Constructor
-     *
-     * @param fileType File type to save the audio in<br>
-     *                 Example, to save as WAVE use AudioFileFormat.Type.WAVE
-     */
-    public Microphone(AudioFileFormat.Type fileType) {
-        setState(CaptureState.CLOSED);
-        setFileType(fileType);
-        initTargetDataLine();
     }
 
     /**

--- a/src/main/java/com/darkprograms/speech/microphone/MicrophoneAnalyzer.java
+++ b/src/main/java/com/darkprograms/speech/microphone/MicrophoneAnalyzer.java
@@ -173,7 +173,7 @@ public class MicrophoneAnalyzer extends Microphone {
 	private double[] applyHanningWindow(double[] signal_in, int pos, int size){
 		for (int i = pos; i < pos + size; i++){
 			int j = i - pos; // j = index into Hann window function
-			signal_in[i] = (double)(signal_in[i] * 0.5 * (1.0 - Math.cos(2.0 * Math.PI * j / size)));
+			signal_in[i] = (signal_in[i] * 0.5 * (1.0 - Math.cos(2.0 * Math.PI * j / size)));
 		}
 		return signal_in;
 	}

--- a/src/main/java/com/darkprograms/speech/recognizer/RecognizerChunked.java
+++ b/src/main/java/com/darkprograms/speech/recognizer/RecognizerChunked.java
@@ -188,7 +188,11 @@ public class RecognizerChunked {
 				} catch (IOException e) {
 					e.printStackTrace();
 				}
-				finally {httpConn.disconnect();}
+				finally {
+					if(httpConn != null) {
+						httpConn.disconnect();
+					}
+				}
 			}
 		}.start();
 	}

--- a/src/main/java/com/darkprograms/speech/util/ChunkedOutputStream.java
+++ b/src/main/java/com/darkprograms/speech/util/ChunkedOutputStream.java
@@ -62,12 +62,19 @@ import java.util.*;
 public class ChunkedOutputStream extends BufferedOutputStream
 {
 
+	private static final byte[] crlf = { 13, 10 };
+	private byte[] lenBytes = new byte[20]; // big enough for any number in hex
+	private List<String> footerNames = new ArrayList<String>();
+	private List<String> footerValues = new ArrayList<String>();
+
+
 	/// Make a ChunkedOutputStream with a default buffer size.
 	// @param out the underlying output stream
 	public ChunkedOutputStream( OutputStream out )
 	{
 		super( out );
 	}
+
 
 	/// Make a ChunkedOutputStream with a specified buffer size.
 	// @param out the underlying output stream
@@ -76,7 +83,6 @@ public class ChunkedOutputStream extends BufferedOutputStream
 	{
 		super( out, size );
 	}
-
 
 	/// Flush the stream.  This will write any buffered output
 	// bytes as a chunk.
@@ -91,15 +97,12 @@ public class ChunkedOutputStream extends BufferedOutputStream
 	}
 
 
-	private Vector<String> footerNames = new Vector<String>();
-	private Vector<String> footerValues = new Vector<String>();
-
 	/// Set a footer.  Footers are much like HTTP headers, except that
 	// they come at the end of the data instead of at the beginning.
 	public void setFooter( String name, String value )
 	{
-		footerNames.addElement( name );
-		footerValues.addElement( value );
+		footerNames.add( name );
+		footerValues.add( value );
 	}
 
 
@@ -116,8 +119,8 @@ public class ChunkedOutputStream extends BufferedOutputStream
 			// Send footers.
 			for ( int i = 0; i < footerNames.size(); ++i )
 			{
-				String name = (String) footerNames.elementAt( i );
-				String value = (String) footerValues.elementAt( i );
+				String name = footerNames.get( i );
+				String value = footerValues.get( i );
 				pout.println( name + ": " + value );
 			}
 		}
@@ -161,10 +164,6 @@ public class ChunkedOutputStream extends BufferedOutputStream
 		flush();
 		writeBuf( b, off, len );
 	}
-
-
-	private static final byte[] crlf = { 13, 10 };
-	private byte[] lenBytes = new byte[20]; // big enough for any number in hex
 
 	/// The only routine that actually writes to the output stream.
 	// This is where chunking semantics are implemented.

--- a/src/main/java/com/darkprograms/speech/util/Complex.java
+++ b/src/main/java/com/darkprograms/speech/util/Complex.java
@@ -114,7 +114,10 @@ public class Complex {
     }
     
     public boolean equals(Complex other){
-    	return (re==other.re) && (im==other.im);
+        if(other != null) {
+            return (re == other.re) && (im == other.im);
+        }
+        return false;
     }
     
 }

--- a/src/main/java/com/darkprograms/speech/util/FFT.java
+++ b/src/main/java/com/darkprograms/speech/util/FFT.java
@@ -28,6 +28,8 @@ package com.darkprograms.speech.util;
 
 public class FFT {
 
+    private FFT() {}
+
     // compute the FFT of x[], assuming its length is a power of 2
     public static Complex[] fft(Complex[] x) {
         int N = x.length;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S1118 - Utility classes should not have public constructors.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2259 - Null pointers should not be dereferenced..
squid:S1905 - Redundant casts should not be used.
squid:S00122 - Statements should be on separate lines.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2259
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S00122
Please let me know if you have any questions.
George Kankava