### PR TITLE
Fix OpenJDK 9 dependency and compiler versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <name>java-speech-api</name>
@@ -81,6 +83,11 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20150729</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.ws</groupId>
+      <artifactId>jaxws-api</artifactId>
+      <version>2.3.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Fixing 'mvn package' errors.  May need verification on Oracle versions.